### PR TITLE
AbstractAreaクラスを作成する

### DIFF
--- a/Abstract_Area.pde
+++ b/Abstract_Area.pde
@@ -1,0 +1,14 @@
+abstract class AbstractArea {
+  int posX;
+  int posY;
+  int tate;
+  int yoko;
+  AbstractArea(int posX, int posY, int yoko, int tate) {
+    this.posX = posX;
+    this.posY = posY;
+    this.yoko = yoko;
+    this.tate = tate;
+  }
+  abstract void draw();
+
+}


### PR DESCRIPTION
すべての種類のAreaクラスが継承するAbstractAreaクラス．
エリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)をフィールドに持つ．
ただし，これらのフィールドが持つ値は実際のピクセル値ではなく，実際のピクセル値をSQUARESIZEで割ったものとなる．
SQUARESIZEは正方形のマス目の一片の大きさを表す．今回は100としている．
コンストラクタではすべての値の初期化をコンストラクタ引数を用いて行う．
抽象メソッドとしてdraw()を持つ *AbstractAreaクラスを継承するすべてのクラスで個別に実装すべきメソッド